### PR TITLE
fix: 浙江省 杭州市 临平 的省市英文错误

### DIFF
--- a/China-City-List-latest.csv
+++ b/China-City-List-latest.csv
@@ -1890,7 +1890,7 @@ Location_ID,Location_Name_EN,Location_Name_ZH,Country_Code,Country_Name_EN,Count
 101210112,Gongshu,拱墅,CN,China,中国,Zhejiang,浙江省,Hangzhou,杭州市,Asia/Shanghai,30.314697,120.150055,330105
 101210113,Xihu,西湖,CN,China,中国,Zhejiang,浙江省,Hangzhou,杭州市,Asia/Shanghai,30.272934,120.147377,330106
 101210114,Binjiang,滨江,CN,China,中国,Zhejiang,浙江省,Hangzhou,杭州市,Asia/Shanghai,30.206615,120.210617,330108
-101210115,Linping,临平,CN,China,中国,Zhejiang Province,浙江省,Hangzhou City,杭州市,Asia/Shanghai,30.419154,120.299222,330113
+101210115,Linping,临平,CN,China,中国,Zhejiang,浙江省,Hangzhou,杭州市,Asia/Shanghai,30.419154,120.299222,330113
 101210201,Huzhou,湖州,CN,China,中国,Zhejiang,浙江省,Huzhou,湖州市,Asia/Shanghai,30.867199,120.102402,330500
 101210202,Changxing,长兴,CN,China,中国,Zhejiang,浙江省,Huzhou,湖州市,Asia/Shanghai,31.004749,119.910126,330522
 101210203,Anji,安吉,CN,China,中国,Zhejiang,浙江省,Huzhou,湖州市,Asia/Shanghai,30.631973,119.687889,330523


### PR DESCRIPTION
其它区域英文都没有带 Province 和 City，这里应该是出了差错